### PR TITLE
画面解像度(アスペクト比)に合わせて UI サイズを調整する機能を追加。

### DIFF
--- a/Assets/Scripts/MosaicStage/FlushScreen.cs
+++ b/Assets/Scripts/MosaicStage/FlushScreen.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+using UnityEngine.UI;
+using DG.Tweening;
+
+public class FlushScreen : MonoBehaviour
+{
+    [SerializeField]
+    private Image imgFlushEffectPanel;
+
+    [SerializeField]
+    private float duration;
+
+    [SerializeField]
+    private int flushCount;
+
+
+    public void Flush() {
+
+        imgFlushEffectPanel.DOColor(new(0.5f, 0, 0, 0.5f), duration)
+            .SetEase(Ease.Linear)
+            .SetLoops(flushCount, LoopType.Yoyo)
+            .OnComplete(() => imgFlushEffectPanel.DOColor(new(0, 0, 0, 0), 0.2f).SetEase(Ease.Linear).SetLink(gameObject))
+            .SetLink(gameObject);
+    }
+}

--- a/Assets/Scripts/MosaicStage/FlushScreen.cs.meta
+++ b/Assets/Scripts/MosaicStage/FlushScreen.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3deb83c46564cdc4a9b801ad1e624e67
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MosaicStage/ResolutionFitter.cs
+++ b/Assets/Scripts/MosaicStage/ResolutionFitter.cs
@@ -1,0 +1,53 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ResolutionFitter : MonoBehaviour
+{
+    [System.Serializable]
+    sealed class Resolution {
+        public int width;
+        public int height;
+
+        public void Set(int width, int height) {
+            this.width = width;
+            this.height = height;
+        }
+    }
+
+    [SerializeField]
+    List<Resolution> resolutions = new();
+
+
+    //void Start()
+    //{
+    //    MeasureScreenSize();
+    //}
+
+
+    public void MeasureScreenSize() {
+        resolutions.Clear();
+
+        int currentIndex = 0;
+        List<string> options = new();
+        Resolution resolution = new();
+        for (int i = 0; i < Screen.resolutions.Length; i++) {
+            if (Screen.resolutions[i].width == Screen.width && Screen.resolutions[i].height == Screen.height) {
+                currentIndex = i;
+            }
+            resolution = new();
+            resolution.width = Screen.resolutions[i].width;
+            resolution.height = Screen.resolutions[i].height;
+            resolutions.Add(resolution);
+            options.Add(Screen.resolutions[i].width.ToString() + "x" + Screen.resolutions[i].height.ToString());
+        }
+
+        resolution.Set(1440, 2880);
+        SetResolution(resolution);
+    }
+
+    void SetResolution(Resolution resolution) {
+        Screen.SetResolution(resolution.width, resolution.height, Screen.fullScreen);
+        Debug.Log($"‰ð‘œ“x•ÏX : { resolution.width } : { resolution.height }");
+    }
+}

--- a/Assets/Scripts/MosaicStage/ResolutionFitter.cs.meta
+++ b/Assets/Scripts/MosaicStage/ResolutionFitter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 47dc220991c6610408271b42f1b74375
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MosaicStage/UnityModifyResolutionScripts.meta
+++ b/Assets/Scripts/MosaicStage/UnityModifyResolutionScripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7ef99e90abee017408b594813039a4e9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MosaicStage/UnityModifyResolutionScripts/CameraStableAspect.cs
+++ b/Assets/Scripts/MosaicStage/UnityModifyResolutionScripts/CameraStableAspect.cs
@@ -1,0 +1,82 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[ExecuteInEditMode()]
+[RequireComponent(typeof(Camera))]
+public class CameraStableAspect : MonoBehaviour
+{
+    [SerializeField]
+    Camera refCamera;
+
+    [SerializeField]
+    int width = 1920;
+
+    [SerializeField]
+    int height = 1080;
+
+    [SerializeField]
+    float pixelPerUnit = 100f;
+
+
+    int m_width = -1;
+    int m_height = -1;
+
+    void Awake()
+    {
+        if( refCamera == null ){
+            refCamera = GetComponent< Camera >();
+        }
+        UpdateCamera();
+    }
+
+    private void Update()
+    {
+        UpdateCameraWithCheck();
+    }
+
+    void UpdateCameraWithCheck()
+    {
+        if(m_width == Screen.width && m_height == Screen.height){
+            return;
+        }
+        UpdateCamera();
+    }
+
+    void UpdateCamera()
+    {
+        float screen_w = (float)Screen.width;
+        float screen_h = (float)Screen.height;
+        float target_w = (float)width;
+        float target_h = (float)height;
+
+        //アスペクト比
+        float aspect =  screen_w / screen_h;        
+        float targetAcpect = target_w / target_h;
+        float orthographicSize = (target_h / 2f / pixelPerUnit);
+
+        //縦に長い
+        if (aspect < targetAcpect)
+        {
+            float bgScale_w = target_w / screen_w;
+            float camHeight = target_h / (screen_h * bgScale_w);
+            refCamera.rect = new Rect( 0f, (1f-camHeight)*0.5f, 1f, camHeight);
+        }
+        // 横に長い
+        else
+        {
+            // カメラのorthographicSizeを横の長さに合わせて設定しなおす
+            float bgScale = aspect / targetAcpect;
+            orthographicSize *= bgScale;
+
+            float bgScale_h = target_h / screen_h;
+            float camWidth = target_w / (screen_w * bgScale_h);
+            refCamera.rect = new Rect( (1f-camWidth)*0.5f, 0f, camWidth, 1f);
+        }
+
+        refCamera.orthographicSize = orthographicSize;
+
+        m_width = Screen.width;
+        m_height = Screen.height;
+    }
+}

--- a/Assets/Scripts/MosaicStage/UnityModifyResolutionScripts/CameraStableAspect.cs.meta
+++ b/Assets/Scripts/MosaicStage/UnityModifyResolutionScripts/CameraStableAspect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9a0579c7208731044a3dada1ffa4a13e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MosaicStage/UnityModifyResolutionScripts/RectScalerWithViewport.cs
+++ b/Assets/Scripts/MosaicStage/UnityModifyResolutionScripts/RectScalerWithViewport.cs
@@ -1,0 +1,87 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[ExecuteInEditMode()]
+public class RectScalerWithViewport : MonoBehaviour
+{
+    [SerializeField]
+    RectTransform refRect = null;
+
+    [SerializeField]
+    Vector2 referenceResolution = new Vector2(1920, 1080);
+
+    [Range(0, 1)]
+    [SerializeField] float matchWidthOrHeight = 0;
+
+    float m_width = -1;
+    float m_height = -1;
+    float m_matchWidthOrHeight = 0f;
+
+    private const float kLogBase = 2;
+
+    private void Awake()
+    {
+        if(refRect == null){
+            refRect = GetComponent<RectTransform>();
+        }
+        UpdateRect();
+    }
+
+    private void Update()
+    {
+        UpdateRectWithCheck();
+    }
+
+    private void OnValidate()
+    {
+        UpdateRect();
+    }
+
+    void UpdateRectWithCheck()
+    {
+        Camera cam = Camera.main;
+        float width = cam.rect.width * Screen.width;
+        float height = cam.rect.height * Screen.height;
+        if(m_width == width && m_height == height && m_matchWidthOrHeight == matchWidthOrHeight ){
+            return;
+        }
+        UpdateRect();
+    }
+
+    void UpdateRect()
+    {
+        if( referenceResolution.x == 0f || referenceResolution.y == 0f){
+            return;
+        }
+        Camera cam = Camera.main;
+        if( cam == null ){
+            return;
+        }
+        float width = cam.rect.width * Screen.width;
+        float height = cam.rect.height * Screen.height;
+        if( width == 0f || height == 0f ){
+            return;
+        }
+
+        // canvas scalerから引用
+        float logWidth = Mathf.Log(width / referenceResolution.x, kLogBase);
+        float logHeight = Mathf.Log(height / referenceResolution.y, kLogBase);
+        float logWeightedAverage = Mathf.Lerp(logWidth, logHeight, matchWidthOrHeight);
+        float scale = Mathf.Pow(kLogBase, logWeightedAverage);
+
+        if( float.IsNaN(scale) || scale <= 0f ){
+            return;
+        }
+
+        refRect.localScale = new Vector3(scale, scale, scale);
+
+        // スケールで縮まるので領域だけ広げる
+        float revScale = 1f / scale;
+        refRect.sizeDelta = new Vector2(width * revScale, height * revScale);
+
+        m_width = width;
+        m_height = height;
+        m_matchWidthOrHeight = matchWidthOrHeight;
+   }
+}

--- a/Assets/Scripts/MosaicStage/UnityModifyResolutionScripts/RectScalerWithViewport.cs.meta
+++ b/Assets/Scripts/MosaicStage/UnityModifyResolutionScripts/RectScalerWithViewport.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 644d68e8489744749b458f135f758508
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UserSettings/Layouts/default-2021.dwlt
+++ b/UserSettings/Layouts/default-2021.dwlt
@@ -8,30 +8,6 @@ MonoBehaviour:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 12004, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_PixelRect:
-    serializedVersion: 2
-    x: 2150.6667
-    y: 260.6667
-    width: 1522
-    height: 806
-  m_ShowMode: 0
-  m_Title: Build Settings
-  m_RootView: {fileID: 4}
-  m_MinSize: {x: 641, y: 603}
-  m_MaxSize: {x: 4001, y: 4023}
-  m_Maximized: 0
---- !u!114 &2
-MonoBehaviour:
-  m_ObjectHideFlags: 52
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
   m_EditorHideFlags: 1
   m_Script: {fileID: 12004, guid: 0000000000000000e000000000000000, type: 0}
   m_Name: 
@@ -43,62 +19,12 @@ MonoBehaviour:
     width: 2560
     height: 1357.3334
   m_ShowMode: 4
-  m_Title: Scene
-  m_RootView: {fileID: 14}
+  m_Title: Hierarchy
+  m_RootView: {fileID: 11}
   m_MinSize: {x: 875, y: 300}
   m_MaxSize: {x: 10000, y: 10000}
   m_Maximized: 1
---- !u!114 &3
-MonoBehaviour:
-  m_ObjectHideFlags: 52
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 12006, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: BuildPlayerWindow
-  m_EditorClassIdentifier: 
-  m_Children: []
-  m_Position:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 1522
-    height: 806
-  m_MinSize: {x: 641, y: 603}
-  m_MaxSize: {x: 4001, y: 4023}
-  m_ActualView: {fileID: 19}
-  m_Panes:
-  - {fileID: 19}
-  m_Selected: 0
-  m_LastSelected: 0
---- !u!114 &4
-MonoBehaviour:
-  m_ObjectHideFlags: 52
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 12010, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Children:
-  - {fileID: 3}
-  m_Position:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 1522
-    height: 806
-  m_MinSize: {x: 641, y: 603}
-  m_MaxSize: {x: 4001, y: 4023}
-  vertical: 0
-  controlID: 8859
---- !u!114 &5
+--- !u!114 &2
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -114,18 +40,18 @@ MonoBehaviour:
   m_Position:
     serializedVersion: 2
     x: 0
-    y: 816.6667
-    width: 1332.6666
-    height: 490.6667
-  m_MinSize: {x: 201, y: 221}
-  m_MaxSize: {x: 4001, y: 4021}
-  m_ActualView: {fileID: 28}
+    y: 872.6667
+    width: 1333.3334
+    height: 434.6667
+  m_MinSize: {x: 200, y: 200}
+  m_MaxSize: {x: 4000, y: 4000}
+  m_ActualView: {fileID: 24}
   m_Panes:
-  - {fileID: 28}
-  - {fileID: 20}
+  - {fileID: 24}
+  - {fileID: 16}
   m_Selected: 0
   m_LastSelected: 1
---- !u!114 &6
+--- !u!114 &3
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -138,19 +64,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Children:
-  - {fileID: 18}
-  - {fileID: 5}
+  - {fileID: 15}
+  - {fileID: 2}
   m_Position:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 1332.6666
+    width: 1333.3334
     height: 1307.3334
   m_MinSize: {x: 100, y: 200}
   m_MaxSize: {x: 8096, y: 16192}
   vertical: 1
-  controlID: 171
---- !u!114 &7
+  controlID: 284
+--- !u!114 &4
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -166,17 +92,17 @@ MonoBehaviour:
   m_Position:
     serializedVersion: 2
     x: 0
-    y: 982.6667
-    width: 673.3334
-    height: 324.6667
+    y: 982
+    width: 672.6666
+    height: 325.33337
   m_MinSize: {x: 101, y: 121}
   m_MaxSize: {x: 4001, y: 4021}
-  m_ActualView: {fileID: 29}
+  m_ActualView: {fileID: 25}
   m_Panes:
-  - {fileID: 29}
+  - {fileID: 25}
   m_Selected: 0
   m_LastSelected: 0
---- !u!114 &8
+--- !u!114 &5
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -189,19 +115,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Children:
-  - {fileID: 13}
-  - {fileID: 7}
+  - {fileID: 10}
+  - {fileID: 4}
   m_Position:
     serializedVersion: 2
-    x: 1886.6666
+    x: 1887.3334
     y: 0
-    width: 673.3334
+    width: 672.6666
     height: 1307.3334
   m_MinSize: {x: 100, y: 200}
   m_MaxSize: {x: 8096, y: 16192}
   vertical: 1
-  controlID: 127
---- !u!114 &9
+  controlID: 217
+--- !u!114 &6
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -217,17 +143,17 @@ MonoBehaviour:
   m_Position:
     serializedVersion: 2
     x: 0
-    y: 720.6667
+    y: 720
     width: 554
-    height: 586.6667
+    height: 587.3334
   m_MinSize: {x: 232, y: 271}
   m_MaxSize: {x: 10002, y: 10021}
-  m_ActualView: {fileID: 24}
+  m_ActualView: {fileID: 20}
   m_Panes:
-  - {fileID: 24}
+  - {fileID: 20}
   m_Selected: 0
   m_LastSelected: 0
---- !u!114 &10
+--- !u!114 &7
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -240,19 +166,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Children:
-  - {fileID: 11}
-  - {fileID: 9}
+  - {fileID: 8}
+  - {fileID: 6}
   m_Position:
     serializedVersion: 2
-    x: 1332.6666
+    x: 1333.3334
     y: 0
     width: 554
     height: 1307.3334
   m_MinSize: {x: 100, y: 200}
   m_MaxSize: {x: 8096, y: 16192}
   vertical: 1
-  controlID: 101
---- !u!114 &11
+  controlID: 259
+--- !u!114 &8
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -270,15 +196,15 @@ MonoBehaviour:
     x: 0
     y: 0
     width: 554
-    height: 720.6667
-  m_MinSize: {x: 202, y: 221}
-  m_MaxSize: {x: 4002, y: 4021}
-  m_ActualView: {fileID: 26}
+    height: 720
+  m_MinSize: {x: 200, y: 200}
+  m_MaxSize: {x: 4000, y: 4000}
+  m_ActualView: {fileID: 22}
   m_Panes:
-  - {fileID: 26}
+  - {fileID: 22}
   m_Selected: 0
   m_LastSelected: 0
---- !u!114 &12
+--- !u!114 &9
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -291,8 +217,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Children:
-  - {fileID: 17}
-  - {fileID: 8}
+  - {fileID: 14}
+  - {fileID: 5}
   m_Position:
     serializedVersion: 2
     x: 0
@@ -302,8 +228,8 @@ MonoBehaviour:
   m_MinSize: {x: 300, y: 200}
   m_MaxSize: {x: 24288, y: 16192}
   vertical: 0
-  controlID: 126
---- !u!114 &13
+  controlID: 216
+--- !u!114 &10
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -320,16 +246,16 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 673.3334
-    height: 982.6667
-  m_MinSize: {x: 276, y: 71}
-  m_MaxSize: {x: 4001, y: 4021}
-  m_ActualView: {fileID: 25}
+    width: 672.6666
+    height: 982
+  m_MinSize: {x: 275, y: 50}
+  m_MaxSize: {x: 4000, y: 4000}
+  m_ActualView: {fileID: 21}
   m_Panes:
-  - {fileID: 25}
+  - {fileID: 21}
   m_Selected: 0
   m_LastSelected: 0
---- !u!114 &14
+--- !u!114 &11
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -342,9 +268,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Children:
-  - {fileID: 15}
   - {fileID: 12}
-  - {fileID: 16}
+  - {fileID: 9}
+  - {fileID: 13}
   m_Position:
     serializedVersion: 2
     x: 0
@@ -357,7 +283,7 @@ MonoBehaviour:
   m_TopViewHeight: 30
   m_UseBottomView: 1
   m_BottomViewHeight: 20
---- !u!114 &15
+--- !u!114 &12
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -379,7 +305,7 @@ MonoBehaviour:
   m_MinSize: {x: 0, y: 0}
   m_MaxSize: {x: 0, y: 0}
   m_LastLoadedLayoutName: 
---- !u!114 &16
+--- !u!114 &13
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -400,7 +326,7 @@ MonoBehaviour:
     height: 20
   m_MinSize: {x: 0, y: 0}
   m_MaxSize: {x: 0, y: 0}
---- !u!114 &17
+--- !u!114 &14
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -413,19 +339,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Children:
-  - {fileID: 6}
-  - {fileID: 10}
+  - {fileID: 3}
+  - {fileID: 7}
   m_Position:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 1886.6666
+    width: 1887.3334
     height: 1307.3334
   m_MinSize: {x: 200, y: 200}
   m_MaxSize: {x: 16192, y: 16192}
   vertical: 0
-  controlID: 170
---- !u!114 &18
+  controlID: 258
+--- !u!114 &15
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -442,69 +368,19 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 1332.6666
-    height: 816.6667
-  m_MinSize: {x: 200, y: 200}
-  m_MaxSize: {x: 4000, y: 4000}
-  m_ActualView: {fileID: 27}
+    width: 1333.3334
+    height: 872.6667
+  m_MinSize: {x: 201, y: 221}
+  m_MaxSize: {x: 4001, y: 4021}
+  m_ActualView: {fileID: 23}
   m_Panes:
-  - {fileID: 27}
   - {fileID: 23}
-  - {fileID: 22}
-  - {fileID: 21}
+  - {fileID: 19}
+  - {fileID: 18}
+  - {fileID: 17}
   m_Selected: 0
   m_LastSelected: 3
---- !u!114 &19
-MonoBehaviour:
-  m_ObjectHideFlags: 52
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 12043, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_MinSize: {x: 640, y: 580}
-  m_MaxSize: {x: 4000, y: 4000}
-  m_TitleContent:
-    m_Text: Build Settings
-    m_Image: {fileID: 0}
-    m_Tooltip: 
-  m_Pos:
-    serializedVersion: 2
-    x: 2150.6667
-    y: 260.6667
-    width: 1522
-    height: 785
-  m_ViewDataDictionary: {fileID: 0}
-  m_OverlayCanvas:
-    m_LastAppliedPresetName: Default
-    m_SaveData: []
-  m_TreeViewState:
-    scrollPos: {x: 0, y: 0}
-    m_SelectedIDs: 
-    m_LastClickedID: 0
-    m_ExpandedIDs: 
-    m_RenameOverlay:
-      m_UserAcceptedRename: 0
-      m_Name: 
-      m_OriginalName: 
-      m_EditFieldRect:
-        serializedVersion: 2
-        x: 0
-        y: 0
-        width: 0
-        height: 0
-      m_UserData: 0
-      m_IsWaitingForDelay: 0
-      m_IsRenaming: 0
-      m_OriginalEventType: 11
-      m_IsRenamingFilename: 0
-      m_ClientGUIView: {fileID: 0}
-    m_SearchString: 
---- !u!114 &20
+--- !u!114 &16
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -536,7 +412,7 @@ MonoBehaviour:
   m_LockTracker:
     m_IsLocked: 0
   m_LastSelectedObjectID: 57650
---- !u!114 &21
+--- !u!114 &17
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -603,7 +479,7 @@ MonoBehaviour:
   m_CurrentEditor: 0
   m_LayerEditor:
     m_SelectedLayerIndex: 0
---- !u!114 &22
+--- !u!114 &18
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -652,7 +528,7 @@ MonoBehaviour:
       m_IsRenaming: 0
       m_OriginalEventType: 11
       m_IsRenamingFilename: 0
-      m_ClientGUIView: {fileID: 18}
+      m_ClientGUIView: {fileID: 15}
     m_SearchString: 
     m_CreateAssetUtility:
       m_EndAction: {fileID: 0}
@@ -780,7 +656,7 @@ MonoBehaviour:
   m_ShowReferencedBuses: 1
   m_ShowBusConnections: 0
   m_ShowBusConnectionsOfSelection: 0
---- !u!114 &23
+--- !u!114 &19
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -809,7 +685,7 @@ MonoBehaviour:
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default
     m_SaveData: []
---- !u!114 &24
+--- !u!114 &20
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -830,10 +706,10 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 2868.6667
-    y: 793.3334
+    x: 2869.3335
+    y: 792.6667
     width: 552
-    height: 565.6667
+    height: 566.3334
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default
@@ -863,10 +739,10 @@ MonoBehaviour:
   m_LockTracker:
     m_IsLocked: 0
   m_FolderTreeState:
-    scrollPos: {x: 0, y: 0}
-    m_SelectedIDs: fe680000
-    m_LastClickedID: 26878
-    m_ExpandedIDs: 00000000586100005a6100005c6100005e61000060610000626100006461000066610000686100006a6100006c6100006e610000e8680000f2680000f668000000ca9a3b
+    scrollPos: {x: 0, y: 96.600006}
+    m_SelectedIDs: 186c0000
+    m_LastClickedID: 27672
+    m_ExpandedIDs: 00000000726400007464000076640000786400007a6400007c6400007e640000806400008264000084640000866400008864000000ca9a3bffffff7f
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -882,7 +758,7 @@ MonoBehaviour:
       m_IsRenaming: 0
       m_OriginalEventType: 11
       m_IsRenamingFilename: 1
-      m_ClientGUIView: {fileID: 9}
+      m_ClientGUIView: {fileID: 6}
     m_SearchString: 
     m_CreateAssetUtility:
       m_EndAction: {fileID: 0}
@@ -894,7 +770,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: 
     m_LastClickedID: 0
-    m_ExpandedIDs: 00000000586100005a6100005c6100005e61000060610000626100006461000066610000686100006a6100006c6100006e610000
+    m_ExpandedIDs: 00000000726400007464000076640000786400007a6400007c6400007e6400008064000082640000846400008664000088640000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -921,24 +797,24 @@ MonoBehaviour:
   m_ListAreaState:
     m_SelectedInstanceIDs: 
     m_LastClickedInstanceID: 0
-    m_HadKeyboardFocusLastEvent: 1
+    m_HadKeyboardFocusLastEvent: 0
     m_ExpandedInstanceIDs: c6230000a28d0000b0620000d65600000000000064580000e86d00009e7b00006e4afcff62580000885e0000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
-      m_Name: Stage
-      m_OriginalName: Stage
+      m_Name: 
+      m_OriginalName: 
       m_EditFieldRect:
         serializedVersion: 2
         x: 0
         y: 0
         width: 0
         height: 0
-      m_UserData: 26898
+      m_UserData: 0
       m_IsWaitingForDelay: 0
       m_IsRenaming: 0
-      m_OriginalEventType: 0
+      m_OriginalEventType: 11
       m_IsRenamingFilename: 1
-      m_ClientGUIView: {fileID: 9}
+      m_ClientGUIView: {fileID: 6}
     m_CreateAssetUtility:
       m_EndAction: {fileID: 0}
       m_InstanceID: 0
@@ -950,7 +826,7 @@ MonoBehaviour:
     m_GridSize: 16
   m_SkipHiddenPackages: 0
   m_DirectoriesAreaWidth: 252
---- !u!114 &25
+--- !u!114 &21
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -971,10 +847,10 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 3422.6667
+    x: 3423.3335
     y: 72.66667
-    width: 672.3334
-    height: 961.6667
+    width: 671.6666
+    height: 961
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default
@@ -992,7 +868,7 @@ MonoBehaviour:
   m_LockTracker:
     m_IsLocked: 0
   m_PreviewWindow: {fileID: 0}
---- !u!114 &26
+--- !u!114 &22
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1013,10 +889,10 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 2868.6667
+    x: 2869.3335
     y: 72.66667
     width: 552
-    height: 699.6667
+    height: 699
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default
@@ -1026,7 +902,7 @@ MonoBehaviour:
       scrollPos: {x: 0, y: 0}
       m_SelectedIDs: 
       m_LastClickedID: 0
-      m_ExpandedIDs: 7e08fdffca08fdff4a0bfdff7c0bfdff28dbfdff32dcfdff0ad1feff56d1feffd6d3feff08d4feffaefdfeff20fffeff720cffff380effff380fffff4234ffffe835ffff2a39ffff463affff923affff123dffff443dffff9046ffffdc46ffff5c49ffff8e49ffff10fbfffff4ffffffdcb300001ab40000deb700001cb8000014b9000052b9000014bd000052bd00004abe000088be000032df000070df0000
+      m_ExpandedIDs: 84f7ffff
       m_RenameOverlay:
         m_UserAcceptedRename: 0
         m_Name: 
@@ -1042,7 +918,7 @@ MonoBehaviour:
         m_IsRenaming: 0
         m_OriginalEventType: 11
         m_IsRenamingFilename: 0
-        m_ClientGUIView: {fileID: 11}
+        m_ClientGUIView: {fileID: 8}
       m_SearchString: 
     m_ExpandedScenes: []
     m_CurrenRootInstanceID: 0
@@ -1050,7 +926,7 @@ MonoBehaviour:
       m_IsLocked: 0
     m_CurrentSortingName: TransformSorting
   m_WindowGUID: 422f3573a55a015409abb2102851506e
---- !u!114 &27
+--- !u!114 &23
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1073,8 +949,8 @@ MonoBehaviour:
     serializedVersion: 2
     x: 1536
     y: 72.66667
-    width: 1331.6666
-    height: 795.6667
+    width: 1332.3334
+    height: 851.6667
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default
@@ -1084,8 +960,8 @@ MonoBehaviour:
       floating: 0
       collapsed: 0
       displayed: 1
-      snapOffset: {x: 0, y: 0}
-      snapOffsetDelta: {x: -98.666626, y: -26}
+      snapOffset: {x: -99.19995, y: -26}
+      snapOffsetDelta: {x: 0, y: 0}
       snapCorner: 3
       id: Tool Settings
       index: 0
@@ -1150,7 +1026,7 @@ MonoBehaviour:
       floating: 0
       collapsed: 0
       displayed: 1
-      snapOffset: {x: 0, y: 24.666666}
+      snapOffset: {x: 0, y: 0}
       snapOffsetDelta: {x: 0, y: 0}
       snapCorner: 0
       id: unity-transform-toolbar
@@ -1298,9 +1174,9 @@ MonoBehaviour:
   m_PlayAudio: 0
   m_AudioPlay: 0
   m_Position:
-    m_Target: {x: 125.48898, y: 237.10197, z: -2.714468}
+    m_Target: {x: 126.18402, y: 190.86243, z: -3.0772173}
     speed: 2
-    m_Value: {x: 126.89046, y: 234.9693, z: -2.5972722}
+    m_Value: {x: 126.18402, y: 190.86243, z: -3.0772173}
   m_RenderMode: 0
   m_CameraMode:
     drawMode: 0
@@ -1351,9 +1227,9 @@ MonoBehaviour:
     speed: 2
     m_Value: {x: 0, y: 0, z: 0, w: 1}
   m_Size:
-    m_Target: 272.1543
+    m_Target: 258.3316
     speed: 2
-    m_Value: 260.43472
+    m_Value: 258.3316
   m_Ortho:
     m_Target: 1
     speed: 2
@@ -1378,7 +1254,7 @@ MonoBehaviour:
   m_SceneVisActive: 1
   m_LastLockedObject: {fileID: 0}
   m_ViewIsLockedToObject: 0
---- !u!114 &28
+--- !u!114 &24
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1400,9 +1276,9 @@ MonoBehaviour:
   m_Pos:
     serializedVersion: 2
     x: 1536
-    y: 889.3334
-    width: 1331.6666
-    height: 469.6667
+    y: 945.3334
+    width: 1332.3334
+    height: 413.6667
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default
@@ -1413,7 +1289,7 @@ MonoBehaviour:
   m_ShowGizmos: 0
   m_TargetDisplay: 0
   m_ClearColor: {r: 0, g: 0, b: 0, a: 0}
-  m_TargetSize: {x: 252, y: 448.6667}
+  m_TargetSize: {x: 221, y: 392.6667}
   m_TextureFilterMode: 0
   m_TextureHideFlags: 61
   m_RenderIMGUI: 1
@@ -1428,10 +1304,10 @@ MonoBehaviour:
     m_VRangeLocked: 0
     hZoomLockedByDefault: 0
     vZoomLockedByDefault: 0
-    m_HBaseRangeMin: -84
-    m_HBaseRangeMax: 84
-    m_VBaseRangeMin: -149.55557
-    m_VBaseRangeMax: 149.55557
+    m_HBaseRangeMin: -73.66667
+    m_HBaseRangeMax: 73.66667
+    m_VBaseRangeMin: -130.8889
+    m_VBaseRangeMax: 130.8889
     m_HAllowExceedBaseRangeMin: 1
     m_HAllowExceedBaseRangeMax: 1
     m_VAllowExceedBaseRangeMin: 1
@@ -1449,29 +1325,29 @@ MonoBehaviour:
       serializedVersion: 2
       x: 0
       y: 21
-      width: 1331.6666
-      height: 448.6667
+      width: 1332.3334
+      height: 392.6667
     m_Scale: {x: 1, y: 1}
-    m_Translation: {x: 665.8333, y: 224.33334}
+    m_Translation: {x: 666.1667, y: 196.33334}
     m_MarginLeft: 0
     m_MarginRight: 0
     m_MarginTop: 0
     m_MarginBottom: 0
     m_LastShownAreaInsideMargins:
       serializedVersion: 2
-      x: -665.8333
-      y: -224.33334
-      width: 1331.6666
-      height: 448.6667
+      x: -666.1667
+      y: -196.33334
+      width: 1332.3334
+      height: 392.6667
     m_MinimalGUI: 1
   m_defaultScale: 1
-  m_LastWindowPixelSize: {x: 1997.5, y: 704.5}
+  m_LastWindowPixelSize: {x: 1998.5, y: 620.5}
   m_ClearInEditMode: 1
   m_NoCameraWarning: 1
   m_LowResolutionForAspectRatios: 01000000000000000000
   m_XRRenderMode: 0
   m_RenderTexture: {fileID: 0}
---- !u!114 &29
+--- !u!114 &25
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1492,10 +1368,10 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 3422.6667
-    y: 1055.3334
-    width: 672.3334
-    height: 303.6667
+    x: 3423.3335
+    y: 1054.6667
+    width: 671.6666
+    height: 304.33337
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default


### PR DESCRIPTION
・CameraStableAspect.cs、RestScalerWithViewport.cs 作成。
　端末の解像度の比率に合わせて、解像度と Canvas のサイズを自動調整する機能を追加。

・FlushScreen.cs 作成。ミス時の画面演出の追加。

・複数の解像度にて確認。デバッグ完了。